### PR TITLE
fix: missing dependencies on next-i18next

### DIFF
--- a/next-i18next/trigger.sh
+++ b/next-i18next/trigger.sh
@@ -15,7 +15,7 @@ echo -e "${NC}"
 echo -e "${NC}"
 echo -e "${GREEN}[Step 1] Installing additional packages${NC}"
 echo ""
-echo -e "Packages: ${GREEN}next-i18next"
+echo -e "Packages: ${GREEN}next-i18next i18next react-i18next"
 echo -e "${NC}"
 yarn add next-i18next i18next react-i18next
 # endregion  //*======== Install Packages ===========

--- a/next-i18next/trigger.sh
+++ b/next-i18next/trigger.sh
@@ -17,7 +17,7 @@ echo -e "${GREEN}[Step 1] Installing additional packages${NC}"
 echo ""
 echo -e "Packages: ${GREEN}next-i18next"
 echo -e "${NC}"
-yarn add next-i18next
+yarn add next-i18next i18next react-i18next
 # endregion  //*======== Install Packages ===========
 
 #region  //*=========== Create Directories ===========


### PR DESCRIPTION
Fix issue #21 by adding `i18next react-i18next` to the packages installed.